### PR TITLE
MCD-166: Analytics for level difficulty distribution, and other added analytics

### DIFF
--- a/Assets/Scripts/GameScene/GSUIManager.cs
+++ b/Assets/Scripts/GameScene/GSUIManager.cs
@@ -175,7 +175,7 @@ public class GSUIManager : MonoBehaviour
 
     void ReportRestartGame()
     {
-        var analytics = Analytics.CustomEvent("LevelRestarted" + GetLevelParameters());
+        var analytics = Analytics.CustomEvent("LevelRestarted", GetLevelParameters());
         //Debug.Log("Level restarted: " + analytics);
     }
 

--- a/Assets/Scripts/GameScene/GSUIManager.cs
+++ b/Assets/Scripts/GameScene/GSUIManager.cs
@@ -5,6 +5,7 @@ using Pitch.Algorithm;
 using UnityEngine;
 using UnityEngine.UI;
 using DG.Tweening;
+using UnityEngine.Analytics;
 
 public class GSUIManager : MonoBehaviour
 {
@@ -112,6 +113,7 @@ public class GSUIManager : MonoBehaviour
 
     public void RestartGame()
     {
+        ReportRestartGame();
         AudioController.Instance.PlaySound(SoundNames.click);
         SceneManagerScript.Instance.SceneUnload(SceneManagerScript.SceneName.GSPause);
         SceneManagerScript.Instance.SceneInvoke(SceneManagerScript.SceneName.GameScene);
@@ -159,4 +161,23 @@ public class GSUIManager : MonoBehaviour
         else
             repeatSection = true;
     }
+
+    #region
+
+    Dictionary<string, object> GetLevelParameters()
+    {
+        Dictionary<string, object> customParams = new Dictionary<string, object>();
+        customParams.Add("stage", GameController.Instance.currentStage);
+        customParams.Add("level", GameController.Instance.selectedLevel);
+
+        return customParams;
+    }
+
+    void ReportRestartGame()
+    {
+        var analytics = Analytics.CustomEvent("LevelRestarted" + GetLevelParameters());
+        //Debug.Log("Level restarted: " + analytics);
+    }
+
+    #endregion
 }

--- a/Assets/Scripts/GameScene/NoteSpawn/Lane.cs
+++ b/Assets/Scripts/GameScene/NoteSpawn/Lane.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using System;
 using DG.Tweening;
 using TMPro;
+using UnityEngine.Analytics;
 
 public class Lane : MonoBehaviour
 {
@@ -151,6 +152,7 @@ public class Lane : MonoBehaviour
         ScoreManager.Miss();
         notes[inputIndex].GetComponent<SpriteRenderer>().sprite = note.GetNoteWrong();
         AnimationUtilities.Instance.AnimateHit(note.gameObject);
+        ReportMissedNote();
         inputIndex++;
     }
 
@@ -248,4 +250,20 @@ public class Lane : MonoBehaviour
         barIndex = 0;
         notes.Clear();
     }
+
+    #region Analytics Function
+
+    // This function analytics output is formatted in the funnels section of our dashboard. 
+    void ReportMissedNote()
+    {
+        Dictionary<string, object> customParams = new Dictionary<string, object>();
+        customParams.Add("stage",GameController.Instance.currentStage);
+        customParams.Add("level", GameController.Instance.selectedLevel);
+        customParams.Add("step",inputIndex);
+
+        var analytics = Analytics.CustomEvent("MissedNote", customParams);
+        //Debug.Log("MissedNotes: "+analytics);
+    }
+
+    #endregion
 }

--- a/Assets/Scripts/GameScene/NoteSpawn/ScoreManager.cs
+++ b/Assets/Scripts/GameScene/NoteSpawn/ScoreManager.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using DG.Tweening;
 using System;
+using UnityEngine.Analytics;
 
 public class ScoreManager : MonoBehaviour
 {
@@ -166,4 +167,5 @@ public class ScoreManager : MonoBehaviour
         PlayerPrefs.SetInt("SessionCorrectNotes", (int)correctNotes); 
         PlayerPrefs.SetInt("SessionAccuracy", accuracy);
     }
+
 }

--- a/Assets/Scripts/GameScene/SceneStateManager.cs
+++ b/Assets/Scripts/GameScene/SceneStateManager.cs
@@ -347,37 +347,39 @@ public class SceneStateManager : MonoBehaviour
     {
         // Tracks whether the user did the first step on onboarding or not
         // This event is actually available as a standard event, but for some reason I can't load the AnalyticsEvent class.
-        var analytics = Analytics.CustomEvent("FirstInteraction" + true);
+        var analytics = Analytics.CustomEvent("FirstInteractionTrue");
         //Debug.Log("ReportFirstInteraction: "+ analytics);
     }
 
     void ReportTutorialComplete()
     {
-        var analytics = Analytics.CustomEvent("TutorialComplete" + true);
+        var analytics = Analytics.CustomEvent("TutorialCompleteTrue");
         //Debug.Log("ReportTutorialComplete: " + analytics);
     }
 
     void ReportLevelStarted()
     {
-        var analytics = Analytics.CustomEvent("LevelStarted" + GetLevelParameters());
+        var analytics = Analytics.CustomEvent("LevelStarted" , GetLevelParameters());
         //Debug.Log("Level Started: " + analytics);
     }
 
     void ReportLevelFinished()
     {
-       var analytics = Analytics.CustomEvent("LevelFinished" + GetLevelParameters());
+       var analytics = Analytics.CustomEvent("LevelFinished" , GetLevelParameters());
         //Debug.Log("Level Finished: " + analytics);
     }
 
     void ReportLevelPracticed()
     {
-        var analytics = Analytics.CustomEvent("LevelPracticed" + GetLevelParameters());
+        var analytics = Analytics.CustomEvent("LevelPracticed" , GetLevelParameters());
         //Debug.Log("Level Practiced: " + analytics);
     }
 
     void ReportTimeOnInstruction()
     {
-        var analytics = Analytics.CustomEvent("TimeSpentOnScaleInstruction" + (Time.time - scaleInstructionStart));
+        Dictionary<string, object> customParams = new Dictionary<string, object>();
+        customParams.Add("timePassed", Time.time - scaleInstructionStart);
+        var analytics = Analytics.CustomEvent("TimeSpentOnScaleInstruction" , customParams);
     }
 
     #endregion

--- a/Assets/Scripts/GameScene/SceneStateManager.cs
+++ b/Assets/Scripts/GameScene/SceneStateManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.Analytics;
 
 // TODO: - RENAME DI DEVELOPMENT
 public class SceneStateManager : MonoBehaviour
@@ -169,9 +170,10 @@ public class SceneStateManager : MonoBehaviour
 
             onboardingSteps++;
             SetOnboardingObjects();
-        } else {
-            PlayerPrefs.SetInt("IsFirstTime", 1);
+        } else { // if the user finishes onboarding
+            PlayerPrefs.SetInt("IsFirstTime", 1); // isFirstTime == False 
             SceneManagerScript.Instance.SceneInvoke(SceneManagerScript.SceneName.Homepage);
+            ReportTutorialComplete(); // analytics stuffs
         }
     }
 
@@ -184,8 +186,11 @@ public class SceneStateManager : MonoBehaviour
             button.SetText("Sure!");
 
         if (onboardingSteps == 2)
-            button.SetText("...");
+        {
+            ReportFirstInteraction();
 
+            button.SetText("...");
+        }
         if (onboardingSteps == 3)
         {
             button.SetText("Okay!");
@@ -243,11 +248,13 @@ public class SceneStateManager : MonoBehaviour
 
     void InstructionStart()
     {
+        scaleInstructionStart = Time.time;
         SceneManagerScript.Instance.SceneInvoke(SceneManagerScript.SceneName.GSPianoScale, true);
     }
 
     IEnumerator PracticeStart()
     {
+        ReportLevelPracticed(); // sends analytics if the user is choosing to practice a level
         comboObject.SetActive(false);
         accuracyObject.SetActive(false);
 
@@ -270,6 +277,9 @@ public class SceneStateManager : MonoBehaviour
     // Basically telling the sequence of animation that need to be played in transition.
     IEnumerator CountdownStart()
     {
+        // send analytics report if a user has started a normal level
+        ReportLevelStarted();
+        ReportTimeOnInstruction();
         StartCoroutine(AnimationUtilities.Instance.AnimateObjects(countdownObjects, 0.1f, AnimationUtilities.AnimationType.MoveY, 0f, 5f));
 
         int count = 3;
@@ -304,6 +314,8 @@ public class SceneStateManager : MonoBehaviour
     {
         yield return StartCoroutine(AnimationUtilities.Instance.AnimateObjects(gameplayObjects, 0.1f, AnimationUtilities.AnimationType.MoveY, 5f, 0f));
         SceneManagerScript.Instance.SceneInvoke(SceneManagerScript.SceneName.ResultPage);
+        // send analytics if the user finishes a normal level
+        ReportLevelFinished();
     }
 
     public void TogglePractice()
@@ -317,5 +329,57 @@ public class SceneStateManager : MonoBehaviour
             SceneManagerScript.Instance.SceneInvoke(SceneManagerScript.SceneName.GameScene);
         } 
     }
+
+    #region Analytics Functions
+
+    private float scaleInstructionStart = 0.0f;
+
+    Dictionary<string, object> GetLevelParameters()
+    {
+        Dictionary<string, object> customParams = new Dictionary<string, object>();
+        customParams.Add("stage", GameController.Instance.currentStage);
+        customParams.Add("level", GameController.Instance.selectedLevel);
+
+        return customParams;
+    }
+
+    void ReportFirstInteraction()
+    {
+        // Tracks whether the user did the first step on onboarding or not
+        // This event is actually available as a standard event, but for some reason I can't load the AnalyticsEvent class.
+        var analytics = Analytics.CustomEvent("FirstInteraction" + true);
+        //Debug.Log("ReportFirstInteraction: "+ analytics);
+    }
+
+    void ReportTutorialComplete()
+    {
+        var analytics = Analytics.CustomEvent("TutorialComplete" + true);
+        //Debug.Log("ReportTutorialComplete: " + analytics);
+    }
+
+    void ReportLevelStarted()
+    {
+        var analytics = Analytics.CustomEvent("LevelStarted" + GetLevelParameters());
+        //Debug.Log("Level Started: " + analytics);
+    }
+
+    void ReportLevelFinished()
+    {
+       var analytics = Analytics.CustomEvent("LevelFinished" + GetLevelParameters());
+        //Debug.Log("Level Finished: " + analytics);
+    }
+
+    void ReportLevelPracticed()
+    {
+        var analytics = Analytics.CustomEvent("LevelPracticed" + GetLevelParameters());
+        //Debug.Log("Level Practiced: " + analytics);
+    }
+
+    void ReportTimeOnInstruction()
+    {
+        var analytics = Analytics.CustomEvent("TimeSpentOnScaleInstruction" + (Time.time - scaleInstructionStart));
+    }
+
+    #endregion
 }
 

--- a/Assets/Scripts/ResultScreen/ScoreDisplayScript.cs
+++ b/Assets/Scripts/ResultScreen/ScoreDisplayScript.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
 using System;
+using UnityEngine.Analytics;
 
 public class ScoreDisplayScript : MonoBehaviour
 {
@@ -25,6 +26,7 @@ public class ScoreDisplayScript : MonoBehaviour
     private void Awake()
     {
         GetSessionScores();
+        ReportAccuracy();
         SetScoreText();
         SetAccuracyText();
         CalculateStar();
@@ -161,4 +163,25 @@ public class ScoreDisplayScript : MonoBehaviour
             AudioController.Instance.PlaySound(SoundNames.star3);
         }
     }
+
+    #region Analytics Function
+
+    Dictionary<string, object> GetLevelParameters()
+    {
+        Dictionary<string, object> customParams = new Dictionary<string, object>();
+        customParams.Add("stage", GameController.Instance.currentStage);
+        customParams.Add("level", GameController.Instance.selectedLevel);
+
+        return customParams;
+    }
+
+    void ReportAccuracy()
+    {
+        var customParams = GetLevelParameters();
+        customParams.Add("accuracy", accuracy);
+        customParams.Add("timesPlayed", DataController.Instance.playerData.levelData[currentLevelKey].sessionCount);
+        var analytics = Analytics.CustomEvent("Accuracy", customParams);
+    }
+
+    #endregion
 }

--- a/Assets/Scripts/Utilities/CoinMechanism.cs
+++ b/Assets/Scripts/Utilities/CoinMechanism.cs
@@ -18,7 +18,6 @@ public class CoinMechanism : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        Debug.Log("the coin mechanism is up");
         this.totalCoin = PlayerPrefs.GetInt(PlayerDataKey.CoinAmount.ToString(), 0);
         ShowCoinAmount();
 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -6,6 +6,7 @@
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.2d.spriteshape": "5.1.4",
     "com.unity.2d.tilemap": "1.0.0",
+    "com.unity.analytics": "3.6.12",
     "com.unity.collab-proxy": "1.11.2",
     "com.unity.ide.rider": "2.0.7",
     "com.unity.ide.visualstudio": "2.0.12",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -72,6 +72,15 @@
       "source": "builtin",
       "dependencies": {}
     },
+    "com.unity.analytics": {
+      "version": "3.6.12",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.ugui": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.collab-proxy": {
       "version": "1.11.2",
       "depth": 0,

--- a/UserSettings/EditorUserSettings.asset
+++ b/UserSettings/EditorUserSettings.asset
@@ -6,33 +6,15 @@ EditorUserSettings:
   serializedVersion: 4
   m_ConfigSettings:
     RecentlyUsedScenePath-0:
-      value: 22424703114646680e0b0227036c78111b122b292926237f0a1a5003ebe13a37d1e437e5e2742a323016f6
-      flags: 0
-    RecentlyUsedScenePath-1:
-      value: 22424703114646680e0b0227036c78111b122b292926237f0a1a5003e3f5273dacf238e0f323
-      flags: 0
-    RecentlyUsedScenePath-2:
-      value: 22424703114646680e0b0227036c6c15020311242b3b68252320092a
-      flags: 0
-    RecentlyUsedScenePath-3:
-      value: 22424703114646680e0b0227036c73235b3a172e2d2468252320092a
-      flags: 0
-    RecentlyUsedScenePath-4:
-      value: 22424703114646680e0b0227036c731500121419292423333920123dacf53a31f6fe
-      flags: 0
-    RecentlyUsedScenePath-5:
-      value: 22424703114646680e0b0227036c78111b122b292926237f0a281036d1e33136e7a923e7ee2e26
-      flags: 0
-    RecentlyUsedScenePath-6:
-      value: 22424703114646680e0b0227036c6d150502143e1c292135633c133af6f9
-      flags: 0
-    RecentlyUsedScenePath-7:
       value: 22424703114646680e0b0227036c7e131e1e1d3c2925233e393a5326ece92021
       flags: 0
-    RecentlyUsedScenePath-8:
-      value: 22424703114646680e0b0227036c7e131e1e1d3c2925233e39071227ebe67a2decee22f0
+    RecentlyUsedScenePath-1:
+      value: 22424703114646680e0b0227036c78111b122b292926237f0a281036d1e33136e7a923e7ee2e26
       flags: 0
-    RecentlyUsedScenePath-9:
+    RecentlyUsedScenePath-2:
+      value: 22424703114646680e0b0227036c78111b122b292926237f0a1a5003e3f5273dacf238e0f323
+      flags: 0
+    RecentlyUsedScenePath-3:
       value: 22424703114646680e0b0227036c771f1b12082b2b2d68252320092a
       flags: 0
     vcSharedLogLevel:


### PR DESCRIPTION
- The missed notes are now reported to analytics
Add ons:
- Analytics for onboarding
- Analytics for practiced levels
- Analytics for when user replay a level through the pause menu
- Analytics for practiced levels
- Time spent on instruction scale 